### PR TITLE
feat: Add NYTimes API integration for fetching and seeding articles

### DIFF
--- a/app/Console/Commands/NYTimesAPI.php
+++ b/app/Console/Commands/NYTimesAPI.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\NYTimesAPIService;
+use App\Helpers\ArticleSeeder;
+use Illuminate\Console\Command;
+
+class NYTimesAPI extends Command
+{
+    protected $signature = 'nytimes:fetch 
+                            {--query= : Search query for articles} 
+                            {--begin-date= : Start date for fetching articles (YYYYMMDD)} 
+                            {--end-date= : End date for fetching articles (YYYYMMDD)} 
+                            {--page=0 : Page number to fetch}';
+
+    protected $description = 'Fetch articles from the New York Times API and seed the database.';
+
+    public function handle()
+    {
+        $query = $this->option('query');
+        $beginDate = $this->option('begin-date');
+        $endDate = $this->option('end-date');
+        $page = (int) $this->option('page');
+
+        try {
+            $nyTimesAPIService = app(NYTimesAPIService::class);
+            $articles = $nyTimesAPIService->fetchArticles($query, $beginDate, $endDate, $page);
+
+            if (!empty($articles)) {
+                // Map NY Times data to standard structure
+                $mappedArticles = $this->mapNYTimesToStandard($articles);
+
+                // Seed articles using ArticleSeeder
+                $articleSeeder = app(ArticleSeeder::class);
+                $articleSeeder->seed($mappedArticles, 'New York Times');
+
+                $this->info('Articles from the New York Times have been seeded successfully.');
+            } else {
+                $this->warn('No articles found in the fetched data.');
+            }
+        } catch (\Exception $e) {
+            \Log::error('Error fetching data from the New York Times API: ' . $e->getMessage());
+            $this->error('Error: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Map NY Times API response to a standard structure for seeder.
+     *
+     * @param array $articles
+     * @return array
+     */
+    private function mapNYTimesToStandard(array $articles): array
+    {
+        return array_map(function ($article) {
+            return [
+                'title' => $article['headline']['main'] ?? 'Unknown Title',
+                'description' => $article['headline']['kicker'] ?? '',
+                'url' => $article['web_url'] ?? '',
+                'publishedAt' => isset($article['pub_date']) ? \Carbon\Carbon::parse($article['pub_date'])->format('Y-m-d H:i:s') : now(),
+                'source' => $article['source'] ?? 'Unknown',
+                'author' => 'Unknown', // NY Times API doesn't provide author directly
+                'category' => $article['section_name'] ?? 'General',
+            ];
+        }, $articles);
+    }
+}

--- a/app/Services/NYTimesAPIService.php
+++ b/app/Services/NYTimesAPIService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class NYTimesAPIService
+{
+    protected string $apiKey;
+    protected string $baseUrl ;
+
+    public function __construct()
+    {
+        $this->apiKey = config('newsapi.sources.nytimes.api_key');
+        $this->baseUrl = config('newsapi.sources.nytimes.base_url');
+
+    }
+
+    /**
+     * Fetch articles from the New York Times API.
+     *
+     * @param string|null $query
+     * @param string|null $beginDate (Format: YYYYMMDD)
+     * @param string|null $endDate (Format: YYYYMMDD)
+     * @param int $page
+     * @return array
+     * @throws \Exception
+     */
+    public function fetchArticles(?string $query = null, ?string $beginDate = null, ?string $endDate = null, int $page = 0): array
+    {
+        $params = [
+            'api-key' => $this->apiKey,
+            'q' => $query,
+            'begin_date' => $beginDate,
+            'end_date' => $endDate,
+            'page' => $page,
+            'sort' => 'newest',
+            'fl' => 'web_url,headline,pub_date,section_name,source'
+        ];
+
+        $response = Http::get($this->baseUrl, $params);
+
+        if ($response->successful()) {
+            return $response->json()['response']['docs'] ?? [];
+        }
+
+        throw new \Exception('Failed to fetch articles: ' . $response->body());
+    }
+}

--- a/config/newsapi.php
+++ b/config/newsapi.php
@@ -10,5 +10,9 @@ return [
             'api_key' => env('GUARDIAN_API_KEY'),
             'base_url' => 'https://content.guardianapis.com/',
         ],
+        'nytimes' => [
+            'api_key' => env('NYT_API_KEY'),
+            'base_url' => 'https://api.nytimes.com/svc/search/v2/articlesearch.json',
+        ],
     ],
 ];


### PR DESCRIPTION
- Implemented `NYTimesAPI` service to handle API requests and fetch articles.
- Created `NYTimesAPI` command for fetching articles with options for query, date range, and pagination.
- Mapped NY Times API response structure to standard format compatible with `ArticleSeeder`.
- Updated `newsapi.php` configuration file to include NY Times API key.

This commit finalizes the robust and reusable integration of the New York Times API for article fetching and database seeding.